### PR TITLE
Fix being unable to extend a lock TTL

### DIFF
--- a/tests/src/Unit/DrupalStoreTest.php
+++ b/tests/src/Unit/DrupalStoreTest.php
@@ -6,7 +6,6 @@ use Drupal\Core\Lock\LockBackendInterface;
 use Lullabot\DrupalSymfonyLock\DrupalStore;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Lock\Exception\LockConflictedException;
-use Symfony\Component\Lock\Exception\NotSupportedException;
 use Symfony\Component\Lock\Key;
 
 /**
@@ -145,10 +144,10 @@ class DrupalStoreTest extends TestCase {
   public function testPutOffExpiration() {
     $this->backend->expects($this->at(0))->method('acquire')
       ->with('test-key', 10)
-      ->willReturn(true);
+      ->willReturn(TRUE);
     $this->backend->expects($this->at(1))->method('acquire')
       ->with('test-key', 10)
-      ->willReturn(false);
+      ->willReturn(FALSE);
 
     // Test a successful extend.
     $this->store->putOffExpiration(new Key('test-key'), 10);


### PR DESCRIPTION
I misunderstood some bits of the locking interface, which came up when actually trying to use this in Drupal. This PR:

* Fixes being unable to acquire a lock. Drupal acquires a lock and sets it's expiration at the same time, while Symfony acquires a lock (infinite expiration I guess?) and then "puts it off".
* Fixes some fatals where the Key object was being used as an array key. We force-cast it to a string to prevent the fatals.