### PR TITLE
wait() returns false, not true when a lock is available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ test_and_cover: &test_and_cover
       # run tests!
       - run: |
           mkdir -p build/logs
-          ./cc-test-reporter --debug before-build
+          ./cc-test-reporter before-build
           vendor/bin/phpunit --testsuite Unit
 
       - store_test_results:
@@ -103,7 +103,7 @@ test_and_cover: &test_and_cover
 
       - run: |
           apt-get update -y && apt-get install git -y
-           ./cc-test-reporter --debug after-build --coverage-input-type clover --exit-code $? test-results/clover.xml
+           ./cc-test-reporter after-build --coverage-input-type clover --exit-code $? test-results/clover.xml
 
 code_fixer: &code_fixer
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ test_and_cover: &test_and_cover
       # run tests!
       - run: |
           mkdir -p build/logs
-          ./cc-test-reporter before-build
+          ./cc-test-reporter --debug before-build
           vendor/bin/phpunit --testsuite Unit
 
       - store_test_results:
@@ -103,7 +103,7 @@ test_and_cover: &test_and_cover
 
       - run: |
           apt-get update -y && apt-get install git -y
-           ./cc-test-reporter after-build --coverage-input-type clover --exit-code $? test-results/clover.xml
+           ./cc-test-reporter --debug after-build --coverage-input-type clover --exit-code $? test-results/clover.xml
 
 code_fixer: &code_fixer
   steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Drupal Symfony Lock
 
-[![CircleCI](https://circleci.com/gh/Lullabot/drupal-symfony-lock.svg?style=svg)](https://circleci.com/gh/Lullabot/drupal-symfony-lock) [![Maintainability](https://api.codeclimate.com/v1/badges/448ece0f1e569fc7d649/maintainability)](https://codeclimate.com/github/Lullabot/drupal-symfony-lock/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/448ece0f1e569fc7d649/test_coverage)](https://codeclimate.com/github/Lullabot/drupal-symfony-lock/test_coverage) [![Packagist](https://img.shields.io/packagist/dt/lullabot/drupal-symfony-lock.svg)](https://packagist.org/packages/lullabot/drupal-symfony-lock)
+[![CircleCI](https://circleci.com/gh/Lullabot/drupal-symfony-lock.svg?style=svg)](https://circleci.com/gh/Lullabot/drupal-symfony-lock) [![Maintainability](https://api.codeclimate.com/v1/badges/68a640924d568cf75781/maintainability)](https://codeclimate.com/github/Lullabot/drupal-symfony-lock/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/68a640924d568cf75781/test_coverage)](https://codeclimate.com/github/Lullabot/drupal-symfony-lock/test_coverage)
 
 Do you want to use a PHP library that requires Symfony's
 [Lock Component](https://symfony.com/doc/3.4/components/lock.html) in your Drupal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Drupal Symfony Lock!
+# Drupal Symfony Lock
 
 [![CircleCI](https://circleci.com/gh/Lullabot/drupal-symfony-lock.svg?style=svg)](https://circleci.com/gh/Lullabot/drupal-symfony-lock) [![Maintainability](https://api.codeclimate.com/v1/badges/448ece0f1e569fc7d649/maintainability)](https://codeclimate.com/github/Lullabot/drupal-symfony-lock/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/448ece0f1e569fc7d649/test_coverage)](https://codeclimate.com/github/Lullabot/drupal-symfony-lock/test_coverage) [![Packagist](https://img.shields.io/packagist/dt/lullabot/drupal-symfony-lock.svg)](https://packagist.org/packages/lullabot/drupal-symfony-lock)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Drupal Symfony Lock
+# Drupal Symfony Lock!
 
 [![CircleCI](https://circleci.com/gh/Lullabot/drupal-symfony-lock.svg?style=svg)](https://circleci.com/gh/Lullabot/drupal-symfony-lock) [![Maintainability](https://api.codeclimate.com/v1/badges/448ece0f1e569fc7d649/maintainability)](https://codeclimate.com/github/Lullabot/drupal-symfony-lock/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/448ece0f1e569fc7d649/test_coverage)](https://codeclimate.com/github/Lullabot/drupal-symfony-lock/test_coverage) [![Packagist](https://img.shields.io/packagist/dt/lullabot/drupal-symfony-lock.svg)](https://packagist.org/packages/lullabot/drupal-symfony-lock)
 

--- a/src/DrupalStore.php
+++ b/src/DrupalStore.php
@@ -77,7 +77,7 @@ class DrupalStore implements StoreInterface {
    */
   private function lock(Key $key) {
     if (!$acquired = $this->lockBackend->acquire((string) $key)) {
-      if ($this->lockBackend->wait((string) $key)) {
+      if (!$this->lockBackend->wait((string) $key)) {
         $acquired = $this->lockBackend->acquire((string) $key);
       }
     }

--- a/tests/src/Unit/DrupalStoreTest.php
+++ b/tests/src/Unit/DrupalStoreTest.php
@@ -75,7 +75,7 @@ class DrupalStoreTest extends TestCase {
 
     $this->backend->expects($this->at(1))->method('wait')
       ->with('test-key')
-      ->willReturn(TRUE);
+      ->willReturn(FALSE);
 
     $this->backend->expects($this->at(2))->method('acquire')
       ->with('test-key')
@@ -127,7 +127,7 @@ class DrupalStoreTest extends TestCase {
 
     $this->backend->expects($this->at(1))->method('wait')
       ->with('test-key')
-      ->willReturn(TRUE);
+      ->willReturn(FALSE);
 
     $this->backend->expects($this->at(2))->method('acquire')
       ->with('test-key')


### PR DESCRIPTION
This is backwards; the Drupal LockInterface returns `FALSE` when the lock is available, not `TRUE`:

```
   * @return bool
   *   TRUE if the lock holds, FALSE if it may be available. You still need to
   *   acquire the lock manually and it may fail again.
```