### PR TITLE
Replace StoreInterface with BlockingStoreInterface, deprecated since symfony 4.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,34 +148,15 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: php:8.0
+      - image: php:8.1
 
     working_directory: ~/repo
 
     <<: *test_and_cover
 
-  build_php73:
-    docker:
-      - image: php:7.3
-
-    working_directory: ~/repo
-
-    environment:
-      - COMPOSER_FLAGS: --prefer-lowest
-
-    <<: *test
-
-  build_php74:
-    docker:
-      - image: php:7.4
-
-    working_directory: ~/repo
-
-    <<: *test
-
   code_fixer:
     docker:
-      - image: php:8.0
+      - image: php:8.1
 
     working_directory: ~/repo
 
@@ -188,8 +169,6 @@ workflows:
   test_cover_workflow:
     jobs:
       - build
-      - build_php73
-      - build_php74
       - code_fixer
 
   nightly:
@@ -203,6 +182,4 @@ workflows:
                 - main
     jobs:
       - build
-      - build_php73
-      - build_php74
       - code_fixer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,11 +148,25 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: php:8.1
-
+      - image: php:8.0
     working_directory: ~/repo
-
     <<: *test_and_cover
+
+  build_php81:
+    docker:
+      - image: php:8.1
+    working_directory: ~/repo
+    environment:
+      - COMPOSER_FLAGS: --prefer-lowest
+    <<: *test
+
+  build_php82:
+    docker:
+      - image: php:8.2
+    working_directory: ~/repo
+    environment:
+      - COMPOSER_FLAGS: --prefer-lowest
+    <<: *test
 
   code_fixer:
     docker:
@@ -169,6 +183,8 @@ workflows:
   test_cover_workflow:
     jobs:
       - build
+      - build_php81
+      - build_php82
       - code_fixer
 
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,8 +164,6 @@ jobs:
     docker:
       - image: php:8.2
     working_directory: ~/repo
-    environment:
-      - COMPOSER_FLAGS: --prefer-lowest
     <<: *test
 
   code_fixer:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.0",
     "drupal/core": "^9.1",
     "symfony/lock": "^4.4"
   },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "^8.0",
-    "drupal/core": "^9.1",
+    "drupal/core": "^9.1||^10",
     "symfony/lock": "^4.4"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^8.0",
     "drupal/core": "^9.1||^10",
-    "symfony/lock": "^4.4"
+    "symfony/lock": "^4.4||^6"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
   }
   ],
   "require": {
-    "php": "^7.3||^8.0",
-    "drupal/core": "^8.5||^9.1",
-    "symfony/lock": "^3.4||^4.0"
+    "php": "^8.1",
+    "drupal/core": "^9.1",
+    "symfony/lock": "^4.4"
   },
   "autoload": {
     "psr-4": {

--- a/src/DrupalStore.php
+++ b/src/DrupalStore.php
@@ -3,14 +3,14 @@
 namespace Lullabot\DrupalSymfonyLock;
 
 use Drupal\Core\Lock\LockBackendInterface;
+use Symfony\Component\Lock\BlockingStoreInterface;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
-use Symfony\Component\Lock\StoreInterface;
 
 /**
  * Wraps a Drupal locking backend with a Symfony store implementation.
  */
-class DrupalStore implements StoreInterface {
+class DrupalStore implements BlockingStoreInterface {
 
   /**
    * The Drupal lock backend.

--- a/src/DrupalStore.php
+++ b/src/DrupalStore.php
@@ -62,7 +62,7 @@ class DrupalStore implements BlockingStoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function exists(Key $key) {
+  public function exists(Key $key): bool {
     return !$this->lockBackend->lockMayBeAvailable((string) $key);
   }
 

--- a/tests/src/Unit/DrupalStoreTest.php
+++ b/tests/src/Unit/DrupalStoreTest.php
@@ -69,15 +69,15 @@ class DrupalStoreTest extends TestCase {
    * @dataProvider retryDataProvider
    */
   public function testRetry($method) {
-    $this->backend->expects($this->at(0))->method('acquire')
+    $this->backend->expects($this->atLeastOnce())->method('acquire')
       ->with('test-key')
       ->willReturn(FALSE);
 
-    $this->backend->expects($this->at(1))->method('wait')
+    $this->backend->expects($this->atLeastOnce())->method('wait')
       ->with('test-key')
       ->willReturn(FALSE);
 
-    $this->backend->expects($this->at(2))->method('acquire')
+    $this->backend->expects($this->atLeastOnce())->method('acquire')
       ->with('test-key')
       ->willReturn(TRUE);
 
@@ -104,11 +104,11 @@ class DrupalStoreTest extends TestCase {
    * Tests when the wait() call fails.
    */
   public function testLockWaitFailed() {
-    $this->backend->expects($this->at(0))->method('acquire')
+    $this->backend->expects($this->atLeastOnce())->method('acquire')
       ->with('test-key')
       ->willReturn(FALSE);
 
-    $this->backend->expects($this->at(1))->method('wait')
+    $this->backend->expects($this->atLeastOnce())->method('wait')
       ->with('test-key')
       ->willReturn(FALSE);
 
@@ -121,15 +121,15 @@ class DrupalStoreTest extends TestCase {
    * Tests when a second acquire() fails.
    */
   public function testLockAcquireFailed() {
-    $this->backend->expects($this->at(0))->method('acquire')
+    $this->backend->expects($this->atLeastOnce())->method('acquire')
       ->with('test-key')
       ->willReturn(FALSE);
 
-    $this->backend->expects($this->at(1))->method('wait')
+    $this->backend->expects($this->atLeastOnce())->method('wait')
       ->with('test-key')
       ->willReturn(FALSE);
 
-    $this->backend->expects($this->at(2))->method('acquire')
+    $this->backend->expects($this->atLeastOnce())->method('acquire')
       ->with('test-key')
       ->willReturn(FALSE);
 
@@ -142,10 +142,10 @@ class DrupalStoreTest extends TestCase {
    * Test extending an expiration.
    */
   public function testPutOffExpiration() {
-    $this->backend->expects($this->at(0))->method('acquire')
+    $this->backend->expects($this->atLeastOnce())->method('acquire')
       ->with('test-key', 10)
       ->willReturn(TRUE);
-    $this->backend->expects($this->at(1))->method('acquire')
+    $this->backend->expects($this->atLeastOnce())->method('acquire')
       ->with('test-key', 10)
       ->willReturn(FALSE);
 

--- a/tests/src/Unit/DrupalStoreTest.php
+++ b/tests/src/Unit/DrupalStoreTest.php
@@ -69,15 +69,15 @@ class DrupalStoreTest extends TestCase {
    * @dataProvider retryDataProvider
    */
   public function testRetry($method) {
-    $this->backend->expects($this->atLeastOnce())->method('acquire')
+    $this->backend->expects($this->at(0))->method('acquire')
       ->with('test-key')
       ->willReturn(FALSE);
 
-    $this->backend->expects($this->atLeastOnce())->method('wait')
+    $this->backend->expects($this->at(1))->method('wait')
       ->with('test-key')
       ->willReturn(FALSE);
 
-    $this->backend->expects($this->atLeastOnce())->method('acquire')
+    $this->backend->expects($this->at(2))->method('acquire')
       ->with('test-key')
       ->willReturn(TRUE);
 
@@ -142,10 +142,10 @@ class DrupalStoreTest extends TestCase {
    * Test extending an expiration.
    */
   public function testPutOffExpiration() {
-    $this->backend->expects($this->atLeastOnce())->method('acquire')
+    $this->backend->expects($this->at(0))->method('acquire')
       ->with('test-key', 10)
       ->willReturn(TRUE);
-    $this->backend->expects($this->atLeastOnce())->method('acquire')
+    $this->backend->expects($this->at(1))->method('acquire')
       ->with('test-key', 10)
       ->willReturn(FALSE);
 


### PR DESCRIPTION
Needed in the process of getting media_mpx D10-compatible.